### PR TITLE
Fix markdown image absolute path support

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -96,6 +96,10 @@
     align-items: center;
 }
 
+body > section.cover {
+    background: url("/docs/assets/images/cover-background.png") center center / cover !important;
+}
+
 .cover blockquote {
     border: 1px solid var(--primary-color)
 }

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -1,5 +1,3 @@
 ><span class="hevort">HevORT</span> DIY 3D-Printer Documentation
 
 [Dive into the Project](pages/home.md ':class=cover-button')
-
-![](/assets/images/cover-background.png)

--- a/docs/pages/electronics-selection.md
+++ b/docs/pages/electronics-selection.md
@@ -16,7 +16,7 @@ At this point as I only have experience with one specific control board, the doc
 
 ### The Duet from [Duet3D](https://duet3d.com/)
 
-![Duet MCU](../assets/images/components/duetboard.png)
+![Duet MCU](docs/assets/images/components/duetboard.png)
 
 Considered by many as the Cadillac of control boards,  
 this open source device has many advantages over the majority of current available boards.   
@@ -72,7 +72,7 @@ We've learned lately that a new Duet Board will see the light soon.  Look at Due
 | [_Duet 2 Pro_](https://forum.duet3d.com/topic/16786/duet-2-pro-4-u/10?_=1592597785623&fbclid=IwAR15hDTJ40d1xfQxxkTIBQmrbcReVolsKxkBpS4tp2ly33M-Ao8jsITXew8) | _TBA_             | _Same as Duet3_                                                                                                             | _TBA_ | _TBA_                       | _TBA_                   |
 
 ## 2. The Stepper Motors
-![E3D High Torque Stepper](../assets/images/components/e3dhightorque.png)
+![E3D High Torque Stepper](docs/assets/images/components/e3dhightorque.png)
 
 [Servo or Stepper?](https://www.amci.com/industrial-automation-resources/plc-automation-tutorials/stepper-vs-servo/)  Very good read on the topic.  
 [Calculate the power rating and max speed of your stepper motor:](https://www.allaboutcircuits.com/tools/stepper-motor-calculator/)

--- a/docs/pages/firmware-configuration/repRapFirmware.md
+++ b/docs/pages/firmware-configuration/repRapFirmware.md
@@ -1,6 +1,6 @@
 # RepRapFirmware Configuration
 
-![Cover Flat](../../assets/images/cover-flat.png)
+![Cover Flat](docs/assets/images/cover-flat.png)
 
 You made it!  your printer is assembled!  Congratulations :)  
 Now you just need to get the Duet control board to know your HevORT. Time for Firmware Configuration!

--- a/docs/pages/frame-calculation.md
+++ b/docs/pages/frame-calculation.md
@@ -32,18 +32,18 @@ HD print area will be smaller due to wider Y carriages and bigger print head.
 around 35mm will be amputed to X and Y.
 |WARNING|
 
-![Frame Calculation Example 1](../assets/images/frame/framecalc1.png)
+![Frame Calculation Example 1](docs/assets/images/frame/framecalc1.png)
 
 ### 2. Refresh the pivot table
 
 #### Right-Click on the pivot table and select *Refresh*.
 
-![Frame Calculation Example 2](../assets/images/frame/framecalc2.png)
+![Frame Calculation Example 2](docs/assets/images/frame/framecalc2.png)
 
 ### Examples
 Here are a couple of snapshots from results of recommended sizes:
 
 
-| STD/HT X315 Y315 Z340                                     | STD/HT X415 Y415 Z440                                     | HD X315 Y315 Z340                                           | HD X415 Y415 Z440                                           |
-|-----------------------------------------------------------|-----------------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------|
-| ![](../assets/images/frame/size-examples/315_315_340.png) | ![](../assets/images/frame/size-examples/415_415_440.png) | ![](../assets/images/frame/size-examples/315_315_340HD.png) | ![](../assets/images/frame/size-examples/415_415_440HD.png) |
+| STD/HT X315 Y315 Z340                                       | STD/HT X415 Y415 Z440                                       | HD X315 Y315 Z340                                             | HD X415 Y415 Z440                                             |
+|-------------------------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------|
+| ![](docs/assets/images/frame/size-examples/315_315_340.png) | ![](docs/assets/images/frame/size-examples/415_415_440.png) | ![](docs/assets/images/frame/size-examples/315_315_340HD.png) | ![](docs/assets/images/frame/size-examples/415_415_440HD.png) |

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -1,6 +1,6 @@
 # Welcome to the HevORT project!
 
-![Cover Image Flat](../assets/images/cover-flat.png)
+![Cover Image Flat](docs/assets/images/cover-flat.png)
 
 ## What is the HevORT?
 

--- a/docs/pages/how-to-print-parts.md
+++ b/docs/pages/how-to-print-parts.md
@@ -1,6 +1,6 @@
 # How to print the HevORT parts?
 
-![Print Banner](../assets/images/how-to-print-parts/printbanner.png)
+![Print Banner](docs/assets/images/how-to-print-parts/printbanner.png)
 
 ## 1. Which material?
 Pretty much any common 3D printing material can be used to print the HevORT parts.  
@@ -42,7 +42,7 @@ Before we start, ensure to make all settings visible by going into:
 `Preferences/Configure Cura.../Settings`  
 Select `Check All` then `Close`
 
-![All Settings](../assets/images/how-to-print-parts/allsettings.png)
+![All Settings](docs/assets/images/how-to-print-parts/allsettings.png)
 
 ____________________________________________________________________________________  
 
@@ -51,7 +51,7 @@ Note that not all settings will be detailed and explained.
 
 ### Quality
 
-![Cura Quality](../assets/images/how-to-print-parts/cura_quality.png)
+![Cura Quality](docs/assets/images/how-to-print-parts/cura_quality.png)
 
 
 | Section | Setting      | Recommended Value       | Comment                                                                                                                                                                     |
@@ -63,7 +63,7 @@ ______________________________________________________________________________
 
 ### Shell
 
-![Cura Shell 1](../assets/images/how-to-print-parts/cura_shell1.png) ![Cura Shell 2](../assets/images/how-to-print-parts/cura_shell2.png)
+![Cura Shell 1](docs/assets/images/how-to-print-parts/cura_shell1.png) ![Cura Shell 2](docs/assets/images/how-to-print-parts/cura_shell2.png)
 
 | Section | Setting              | Recommended Value | Comment                                                                                                 |
 |---------|----------------------|-------------------|---------------------------------------------------------------------------------------------------------|
@@ -72,7 +72,7 @@ ______________________________________________________________________________
 
 ### Infill
 
-![Cura Infill Settings](../assets/images/how-to-print-parts/cura_infill1.png)
+![Cura Infill Settings](docs/assets/images/how-to-print-parts/cura_infill1.png)
 
 | Section | Setting             | Recommended Value | Comment                                                                                                                                                                                                                                                                                                                                                                      |
 |---------|---------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/pages/mods/spy-eye.md
+++ b/docs/pages/mods/spy-eye.md
@@ -1,6 +1,6 @@
 # The SpEye Filament and Jam Detector
 
-![SpyEye Banner](../../assets/images/mods/spy-eye/spybanner.png)
+![SpyEye Banner](docs/assets/images/mods/spy-eye/spybanner.png)
 
 Not only will this unit pause your print when you are out of filament, but it will also do the same if you have a spool jam.  
 Sensitivity can be adjusted to adapt to your setup.
@@ -54,7 +54,7 @@ _These instructions assume you are using a Duet2 (Wi-Fi or ethernet) controller 
 |         S (Signal)         |               E0 STOP               |
 |          V (VCC)           |                +3.3V                |
 
-![SpyEye Duet Connection](../../assets/images/mods/spy-eye/duetwifi_speye.png)
+![SpyEye Duet Connection](docs/assets/images/mods/spy-eye/duetwifi_speye.png)
 
 2. Place the following line of code within your config.g file from your Duet.  
 ```reprap config.g

--- a/docs/pages/thankyou.md
+++ b/docs/pages/thankyou.md
@@ -1,4 +1,4 @@
-![alt text](/images/Coverflat.png)
+![alt text](docs/assets/images/cover-flat.png)
 # Thank you for your support!
 
 Your contribution will help me to cover some of the costs related to the research and development, the tooling, the parts and the software subscriptions needed in the making of the HevORT project.  I really appreciate your help.

--- a/index.html
+++ b/index.html
@@ -48,6 +48,52 @@
       readyTransition: true,
       responsiveTables: true
     },
+    markdown: {
+      // https://marked.js.org/#/USING_PRO.md#renderer
+      renderer: {
+        image: function(href, extra, title) {
+          let attrs = [];
+          let config = {};
+          if (extra) {
+            extra = extra
+                    .replace(/(?:^|\s):([\w-]+:?)=?([\w-%]+)?/g, (m, key, value) => {
+                      if (key.indexOf(':') === -1) {
+                        config[key] = (value && value.replace(/&quot;/g, '')) || true;
+                        return '';
+                      }
+
+                      return m;
+                    })
+                    .trim();
+          }
+
+          if (config.size) {
+            const [width, height] = config.size.split('x');
+            if (height) {
+              attrs.push(`width="${width}" height="${height}"`);
+            } else {
+              attrs.push(`width="${width}"`);
+            }
+          }
+
+          if (config.class) {
+            attrs.push(`class="${config.class}"`);
+          }
+
+          if (config.id) {
+            attrs.push(`id="${config.id}"`);
+          }
+
+          if (attrs.length > 0) {
+            return `<img src="${href}" data-origin="${href}" alt="${title}" ${attrs.join(
+                    ' '
+            )} />`;
+          }
+
+          return `<img src="${href}" data-origin="${href}" alt="${title}"${attrs} />`;
+        }
+      }
+    },
     vueComponents: {
       'grid': {
         template: `


### PR DESCRIPTION
- Allow the use of absolute paths in markdown images `![title](url)`
- Replace all relative paths with absolute paths
- Move cover image setting to css