### PR TITLE
Allow defining a small hint text on item-button elements

### DIFF
--- a/docs/assets/plugins/hevort-button/style.css
+++ b/docs/assets/plugins/hevort-button/style.css
@@ -9,6 +9,22 @@
     color: white !important;
     font-weight: bolder;
     justify-content: center;
+    position: relative;
+}
+
+.hevort-btn-hint {
+    position: absolute;
+    bottom: -0.4rem;
+    left: 0.25rem;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 1rem;
+    background: var(--primary-background-color);
+    padding: 0 0.2rem;
+    border-radius: 0.5rem;
+    font-weight: initial;
 }
 
 .hevort-btn:hover {

--- a/docs/pages/documentation-docs.md
+++ b/docs/pages/documentation-docs.md
@@ -118,6 +118,14 @@ To have a unified way of showing a large amount of related parts we use the grid
   - icon
     - **OPTIONAL**
     - css class added to ``<i>`` element. See [FontAwesome](https://fontawesome.com/icons)
+  - hint
+    - **OPTIONAL**
+    - a small hint text displayed at the bottom left of the button (placed on the border)
+    - some hint texts are automatically generated. These can be overridden by manually defining the **hint** prop
+      - setting it to the text "null" will hide it.
+      - Automatically generated hints are:
+        - **url** starts with `https://a360.` results in ``f360`` text
+        - **url** ends with `.step` results in ``step`` text
 - credits
   - **OPTIONAL**
   - content

--- a/index.html
+++ b/index.html
@@ -204,11 +204,38 @@
             type: String,
             default: () => "_blank"
           },
+          hint: String,
           icon: String,
           url: String,
         },
+        data: () => {
+          return {
+            hintText: null
+          }
+        },
+        computed: {
+          getHint: function () {
+            if (this.hint) {
+              if (this.hint === "null") {
+                return null;
+              }
+              return this.hint;
+            }
+
+            if (/^https:\/\/a360\./m.test(this.url)) {
+              return "f360";
+            }
+
+            if (/\.step$/m.test(this.url)) {
+              return "step";
+            }
+
+            return null;
+          },
+        },
         template: `
           <a class="hevort-btn" :href="url" :target="target">
+          <span v-if="getHint" class="hevort-btn-hint" v-html="getHint" />
           <span class="hevort-btn-text" :style="[icon ? {'textAlign': 'center', 'marginLeft': 'auto'} : {}]">
                <slot></slot>
              </span>


### PR DESCRIPTION
- texts like `step` and `f360` are auto generated based on the supplied button url
- others can be defined by using the `hint` prop on an item-button element
- setting `hint` to the text "null" will remove the hint even if it would have been set by the url value

![2022-06-29_10-58](https://user-images.githubusercontent.com/19359112/176399881-ec08be1a-4fcf-4245-bf64-cb8cdc8be7b7.png)