### PR TITLE
Add ability to search grid-items in the grid

### DIFF
--- a/docs/assets/css/grid.css
+++ b/docs/assets/css/grid.css
@@ -1,10 +1,38 @@
 @media screen and (max-width: 768px) {
-    .grid {
+    .grid-data-container {
         grid-template-columns: 1fr !important;
     }
 }
 
 .grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+}
+
+.grid-search-label {
+    color: var(--primary-color)
+}
+
+.grid-search {
+    width: 100%;
+}
+
+.grid-search-input:focus-visible {
+    outline-color: var(--primary-color) !important;
+}
+
+.grid-search-input {
+    width: 100%;
+    background: var(--primary-background-color);
+    border-radius: 2rem;
+    border: 2px solid var(--primary-color);
+    color: var(--base-color);
+    padding: 0.25rem 1rem;
+}
+
+.grid-data-container {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     gap: 2rem;
@@ -217,4 +245,20 @@
     padding: 0.5rem;
     font-weight: bold;
     margin-left: 1rem;
+}
+
+.grid-item-tag-container {
+    padding: 0 0.5rem;
+    display: flex;
+    gap: 0.5rem
+}
+
+.grid-item-tag {
+
+}
+
+.grid-item-tag:hover {
+    color: var(--link-color);
+    cursor: pointer;
+    text-decoration: underline;
 }

--- a/docs/assets/css/grid.css
+++ b/docs/assets/css/grid.css
@@ -23,13 +23,26 @@
     outline-color: var(--primary-color) !important;
 }
 
+.grid-search-input:focus, input:focus{
+    outline: solid 1px var(--primary-color);
+}
+
 .grid-search-input {
     width: 100%;
     background: var(--primary-background-color);
     border-radius: 2rem;
-    border: 2px solid var(--primary-color);
+    border: 1.5px solid var(--primary-color);
     color: var(--base-color);
     padding: 0.25rem 1rem;
+}
+
+.grid-search-info {
+    font-size: small;
+    padding: 0 1rem;
+}
+
+.grid-search-info-filter {
+    color: var(--primary-color);
 }
 
 .grid-data-container {

--- a/docs/assets/css/grid.css
+++ b/docs/assets/css/grid.css
@@ -261,17 +261,40 @@
 }
 
 .grid-item-tag-container {
-    padding: 0 0.5rem;
     display: flex;
-    gap: 0.5rem
+    flex-direction: column;
+    padding: 0 0.5rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 2px solid var(--primary-color);
+}
+
+.grid-item-tag-inner-container {
+    flex-wrap: wrap;
+    display: flex;
+    gap: 0.5rem 0.5rem;
+    padding: 0.5rem 0;
 }
 
 .grid-item-tag {
+    background: var(--secondary-background-color);
+    border: solid 2px var(--primary-color);
+    border-radius: 0.5rem;
+    padding: 0 0.5rem;
+    font-size: 0.8rem;
+    color: white;
+}
 
+.grid-item-tag-inner-container > .grid-item-tag-remove:hover {
+    background: red;
+    color: white;
+}
+
+.grid-item-tag:active {
+    transform: translateY(4px) !important;
 }
 
 .grid-item-tag:hover {
-    color: var(--link-color);
+    background: var(--link-color);
+    color: black;
     cursor: pointer;
-    text-decoration: underline;
 }

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -57,10 +57,6 @@
     --folder-closed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='11.2' viewBox='0 0 7 11.2'%3E%3Cpath d='M1.5 1.5l4 4.1 -4 4.1' stroke-width='1.5' stroke='rgb%28209, 255, 42%29' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
 }
 
-.hevort-color {
-    color: var(--primary-color);
-}
-
 .table-wrapper {
     border: 1px solid var(--primary-color);
     padding: 0;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -57,6 +57,10 @@
     --folder-closed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='11.2' viewBox='0 0 7 11.2'%3E%3Cpath d='M1.5 1.5l4 4.1 -4 4.1' stroke-width='1.5' stroke='rgb%28209, 255, 42%29' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
 }
 
+.hevort-color {
+    color: var(--primary-color);
+}
+
 .table-wrapper {
     border: 1px solid var(--primary-color);
     padding: 0;

--- a/docs/pages/component-selection.md
+++ b/docs/pages/component-selection.md
@@ -6,193 +6,229 @@ The HevORT project has been designed to be modular. This means you can select fr
 This is the base of the HevORT
 
 <grid v-bind:config="{gridTemplateColumns: '1fr 1fr'}">
-  <item title="Frame" image="docs/assets/images/components/FrameThumb.png">
-    <description slot="description">
-      The bare base frame with a side electronics bay
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://a360.co/3dCjsfY">Frame Hardware Map</item-button>
-      <item-button url="https://a360.co/2xUD9B9">CAD File</item-button>
-      <item-button url="bom/BOM_Frame_ElecExt.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_Frame_ElecExt.xlsx">BOM<br>Download</item-button>
-    </buttons>
-    <tags slot="tags">
-        <item-tag>Hallo</item-tag>
-        <item-tag>Test</item-tag>
-    </tags>
-  </item>
-  <item title="Enclosure" image="docs/assets/images/components/AcidBeeThumb.png">
-    <description slot="description">
-      The Acid Bee Enclosure
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:5188673">Thingiverse</item-button>
-      <item-button url="https://a360.co/3HD6rlY">CAD File</item-button>
-      <item-button url="bom/BOM_Enclosure_AcidBee.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_Enclosure_AcidBee.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
+<item title="Frame" image="docs/assets/images/components/FrameThumb.png">
+  <description slot="description">
+    The bare base frame with a side electronics bay
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://a360.co/3dCjsfY">Frame Hardware Map</item-button>
+    <item-button url="https://a360.co/2xUD9B9">CAD File</item-button>
+    <item-button url="bom/BOM_Frame_ElecExt.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_Frame_ElecExt.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
+<item title="Enclosure" image="docs/assets/images/components/AcidBeeThumb.png">
+  <description slot="description">
+    The Acid Bee Enclosure
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:5188673">Thingiverse</item-button>
+    <item-button url="https://a360.co/3HD6rlY">CAD File</item-button>
+    <item-button url="bom/BOM_Enclosure_AcidBee.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_Enclosure_AcidBee.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
 </grid>
 
 ## 2. XY Gantry
 You will find below the various configuration for XY Gantry.  Select one in function of your needs:
 
 <grid>
-  <item title="Standard XY" image="docs/assets/images/components/XYThumb.png">
-    <description slot="description">
-      This version is suited for the commonly available GT2 pulleys.
-      <br>These pulleys available from China and other location are 9mm thick and have wider flanges(lips).
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4184477">Thingiverse</item-button>
-      <item-button url="https://a360.co/2UEaOHa">CAD File</item-button>
-      <item-button url="bom/BOM_XY_STD.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_XY_STD.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="(HT) XY High Temp" image="docs/assets/images/components/XYHTThumb.png">
-    <description slot="description">
-      The High Temp version of the XY gantry features 5mm bore pulleys. These are slightly thicker (10mm) and have a
-      narrower lips.
-      <br>Note that due to extreme compactness of some components,
-      <br>transition bushings are necessary to fit the 5mm bore onto 3mm hardware.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4402495">Thingiverse</item-button>
-      <item-button url="https://a360.co/3ABEubX">CAD File</item-button>
-      <item-button url="bom/BOM_XYHT.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_XYHT.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="(HD9) XY Heavy Duty 9mm" image="docs/assets/images/components/XYHD9Thumb.png">
-    <description slot="description">
-      This XY Gantry will fit on the same frame as the Standard and HT version of the XY Gantry.
-      <br>The XYHD gantry are meant for very large printers or for the ones with very high performance in mind.
-      <br><br>Featuring:
-      <br>9mm or 12mm 2GT Belt,
-      <br>Center Pulley Bore 5mm Dowell Pins,
-      <br>MGN12H instead of MGN12C and more...
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4629715">Thingiverse</item-button>
-      <item-button url="https://a360.co/35p2MH0">CAD File</item-button>
-      <item-button url="bom/BOM_XYHD9.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_XYHD9.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="(HD12) XY Heavy Duty 12mm" image="docs/assets/images/components/XYHD12Thumb.png">
-    <description slot="description">
-      This XY Gantry will fit on the same frame as the Standard and HT version of the XY Gantry.
-      <br>The XYHD gantry are meant for very large printers or for the ones with very high performance in mind.
-      <br><br>Featuring:
-      <br>9mm or 12mm 2GT Belt,
-      <br>Center Pulley Bore 5mm Dowell Pins,
-      <br>MGN12H instead of MGN12C and more...
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4625509">Thingiverse</item-button>
-      <item-button url="https://a360.co/3dxzysP">CAD File</item-button>
-      <item-button url="bom/BOM_XYHD12.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_XYHD12.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
+<item title="Standard XY" image="docs/assets/images/components/XYThumb.png">
+  <description slot="description">
+    This version is suited for the commonly available GT2 pulleys.
+    <br>These pulleys available from China and other location are 9mm thick and have wider flanges(lips).
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4184477">Thingiverse</item-button>
+    <item-button url="https://a360.co/2UEaOHa">CAD File</item-button>
+    <item-button url="bom/BOM_XY_STD.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_XY_STD.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>6mm belt</item-tag>
+    <item-tag>Nema17</item-tag>
+  </tags>
+</item>
+<item title="(HT) XY High Temp" image="docs/assets/images/components/XYHTThumb.png">
+  <description slot="description">
+    The High Temp version of the XY gantry features 5mm bore pulleys. These are slightly thicker (10mm) and have a
+    narrower lips.
+    <br>Note that due to extreme compactness of some components,
+    <br>transition bushings are necessary to fit the 5mm bore onto 3mm hardware.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4402495">Thingiverse</item-button>
+    <item-button url="https://a360.co/3ABEubX">CAD File</item-button>
+    <item-button url="bom/BOM_XYHT.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_XYHT.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>6mm belt</item-tag>
+    <item-tag>Nema17</item-tag>
+  </tags>
+</item>
+<item title="(HD9) XY Heavy Duty 9mm" image="docs/assets/images/components/XYHD9Thumb.png">
+  <description slot="description">
+    This XY Gantry will fit on the same frame as the Standard and HT version of the XY Gantry.
+    <br>The XYHD gantry are meant for very large printers or for the ones with very high performance in mind.
+    <br><br>Featuring:
+    <br>9mm 2GT Belt,
+    <br>Center Pulley Bore 5mm Dowell Pins,
+    <br>MGN12H instead of MGN12C and more...
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4629715">Thingiverse</item-button>
+    <item-button url="https://a360.co/35p2MH0">CAD File</item-button>
+    <item-button url="bom/BOM_XYHD9.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_XYHD9.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>9mm belt</item-tag>
+    <item-tag>Nema17</item-tag>
+    <item-tag>Nema23</item-tag>
+    <item-tag>Servo</item-tag>
+  </tags>
+</item>
+<item title="(HD12) XY Heavy Duty 12mm" image="docs/assets/images/components/XYHD12Thumb.png">
+  <description slot="description">
+    This XY Gantry will fit on the same frame as the Standard and HT version of the XY Gantry.
+    <br>The XYHD gantry are meant for very large printers or for the ones with very high performance in mind.
+    <br><br>Featuring:
+    <br>12mm 2GT Belt,
+    <br>Center Pulley Bore 5mm Dowell Pins,
+    <br>MGN12H instead of MGN12C and more...
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4625509">Thingiverse</item-button>
+    <item-button url="https://a360.co/3dxzysP">CAD File</item-button>
+    <item-button url="bom/BOM_XYHD12.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_XYHD12.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>12mm belt</item-tag>
+    <item-tag>Nema17</item-tag>
+    <item-tag>Nema23</item-tag>
+    <item-tag>Servo</item-tag>
+  </tags>
+
+</item>
 </grid>
 
 ### Further options
 Alternative version/improvements to the above Gantry parts (like Carbon fibre)
 
 <grid>
-  <item title="(XYHT) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_XYHT_CFX_MGN9_Thumb.jpg">
-    <description slot="description">
-      A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4880808">Thingiverse</item-button>
-      <item-button url="https://a360.co/3z3ofD8">CAD File</item-button>
-      <item-button url="bom/Option_XYHT_CFX_MGN9.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/Option_XYHT_CFX_MGN9.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="(HD9) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_HD9_CFX_MGN9_Thumb.jpg">
-    <description slot="description">
-      A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://github.com/MirageC79/HevORT/tree/master/files/STL/HD9/Option_HD9_CFx">STLs</item-button>
-      <item-button url="https://a360.co/3ttC8sp">CAD File</item-button>
-      <item-button url="bom/Option_HD9_CFx_MGN9.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/Option_HD9_CFx_MGN9.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="(HD12) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_HD12_CFX_MGN9_Thumb.jpg">
-    <description slot="description">
-      A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4886459">Thingiverse</item-button>
-      <item-button url="https://a360.co/3gqVqt4">CAD File</item-button>
-      <item-button url="bom/Option_HD12_CFx_MGN9.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/Option_HD12_CFx_MGN9.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
+<item title="(XYHT) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_XYHT_CFX_MGN9_Thumb.jpg">
+  <description slot="description">
+    A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4880808">Thingiverse</item-button>
+    <item-button url="https://a360.co/3z3ofD8">CAD File</item-button>
+    <item-button url="bom/Option_XYHT_CFX_MGN9.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/Option_XYHT_CFX_MGN9.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>6mm belt</item-tag>
+  </tags>
+</item>
+<item title="(HD9) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_HD9_CFX_MGN9_Thumb.jpg">
+  <description slot="description">
+    A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://github.com/MirageC79/HevORT/tree/master/files/STL/HD9/Option_HD9_CFx">STLs</item-button>
+    <item-button url="https://a360.co/3ttC8sp">CAD File</item-button>
+    <item-button url="bom/Option_HD9_CFx_MGN9.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/Option_HD9_CFx_MGN9.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>9mm belt</item-tag>
+  </tags>
+</item>
+<item title="(HD12) MGN9 Carbon Fiber X-Axis" image="docs/assets/images/components/OPTION_HD12_CFX_MGN9_Thumb.jpg">
+  <description slot="description">
+    A 2020 Carbon Fiber Tube is replacing X extrusion for huge weight saving.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4886459">Thingiverse</item-button>
+    <item-button url="https://a360.co/3gqVqt4">CAD File</item-button>
+    <item-button url="bom/Option_HD12_CFx_MGN9.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/Option_HD12_CFx_MGN9.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>12mm belt</item-tag>
+  </tags>
+</item>
 </grid>
 
 ## 3. Z Axis and Build Plate
 Choose your weapon wisely ;)
 
 <grid>
-  <item title="ZR" image="docs/assets/images/components/ZRThumb.png" status="Retired">
-    <description slot="description">
-      This initial version of the Self Leveling Z axis on MGN rails from the HevORT
-      <br>works just fine if you are using quality Ball screws with excellent frame alignment as well as perfect
-      tolerances printed parts...
-      <br>Sounds impossible to get?
-      <br><br>look at V2 below :)
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4184059">Thingiverse</item-button>
-      <item-button url="https://a360.co/3gweJiw">CAD File</item-button>
-    </buttons>
-  </item>
-  <item title="ZR V2 (Wobble wings)" image="docs/assets/images/components/ZRV2Thumb.png">
-    <description slot="description">
-      Some may say, get proper alignment, get quality parts, go back to lead screw... Well
-      <br><br>The size of the bed on that printer makes it quite heavy.
-      <br>Moving it down and up in a non planar printing mode will get standards lead screw to wear out pretty quick.
-      <br><br>So for the ones of us who did not win the cheap ball screw lottery,
-      <br><br>this version of ZR system introduces Z wobble management using magnets and ball bearings.
-      <br>Also a second thrust bearing was added to allow the use of a M10X1.00 nut to secure the ball screw better.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4387638">Thingiverse</item-button>
-      <item-button url="https://a360.co/3gweJiw">CAD File</item-button>
-      <item-button url="bom/BOM_ZR_V2.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_ZR_V2.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="ZR V2.5" image="docs/assets/images/components/ZR_V2.5_Thumb.jpg">
-    <description slot="description">
-      Using the same Z wobble management as V2, this new version integrates
-      <br><br>2 new features:<br>First, A double row angular contact bearing is now offering better axial load support to
-      the ball screw.
-      <br><br>Second, a quality shaft collar from Ruland is providing a better resting shoulder to the thrust bearing
-      <br>than the poor half lip of a thread the SFU1204 usually offers.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4723500">Thingiverse</item-button>
-      <item-button url="https://a360.co/3bSwQzF">CAD File</item-button>
-      <item-button url="bom/BOM_ZR_V2.5.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_ZR_V2.5.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="HyperCube Evolution Z Adapters" image="" status="TBD">
-    <description slot="description">
-      - Upcoming -
-      <br>This option will let you use standard <a href="https://www.thingiverse.com/thing:2254103">Hypercube Evolution
-      from SCOTT_3D</a>
-      <br>Z installation to your HevORT printer.
-    </description>
-  </item>
+<item title="ZR" image="docs/assets/images/components/ZRThumb.png" status="Retired">
+  <description slot="description">
+    This initial version of the Self Leveling Z axis on MGN rails from the HevORT
+    <br>works just fine if you are using quality Ball screws with excellent frame alignment as well as perfect
+    tolerances printed parts...
+    <br>Sounds impossible to get?
+    <br><br>look at V2 below :)
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4184059">Thingiverse</item-button>
+    <item-button url="https://a360.co/3gweJiw">CAD File</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
+<item title="ZR V2 (Wobble wings)" image="docs/assets/images/components/ZRV2Thumb.png">
+  <description slot="description">
+    Some may say, get proper alignment, get quality parts, go back to lead screw... Well
+    <br><br>The size of the bed on that printer makes it quite heavy.
+    <br>Moving it down and up in a non planar printing mode will get standards lead screw to wear out pretty quick.
+    <br><br>So for the ones of us who did not win the cheap ball screw lottery,
+    <br><br>this version of ZR system introduces Z wobble management using magnets and ball bearings.
+    <br>Also a second thrust bearing was added to allow the use of a M10X1.00 nut to secure the ball screw better.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4387638">Thingiverse</item-button>
+    <item-button url="https://a360.co/3gweJiw">CAD File</item-button>
+    <item-button url="bom/BOM_ZR_V2.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_ZR_V2.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
+<item title="ZR V2.5" image="docs/assets/images/components/ZR_V2.5_Thumb.jpg">
+  <description slot="description">
+    Using the same Z wobble management as V2, this new version integrates
+    <br><br>2 new features:<br>First, A double row angular contact bearing is now offering better axial load support to
+    the ball screw.
+    <br><br>Second, a quality shaft collar from Ruland is providing a better resting shoulder to the thrust bearing
+    <br>than the poor half lip of a thread the SFU1204 usually offers.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4723500">Thingiverse</item-button>
+    <item-button url="https://a360.co/3bSwQzF">CAD File</item-button>
+    <item-button url="bom/BOM_ZR_V2.5.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_ZR_V2.5.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
+<item title="HyperCube Evolution Z Adapters" image="" status="TBD">
+  <description slot="description">
+    - Upcoming -
+    <br>This option will let you use standard <a href="https://www.thingiverse.com/thing:2254103">Hypercube Evolution
+    from SCOTT_3D</a>
+    <br>Z installation to your HevORT printer.
+  </description>
+</item>
 </grid>
 
 ## 4. Print Head
@@ -202,48 +238,56 @@ This list will capture the ones I created plus the ones from members of the [FB 
 All configuration here below include the [BLtouch from Antclabs](https://www.antclabs.com/bltouch) as a Z probe.
 
 <grid>
-  <item title="E3D Hemera" image="docs/assets/images/components/HemeraThumb.png">
-    <description slot="description">
-      Including configuration for E3D V6,
-      <br>Volcano
-      <br>and Super Volcano heatblocks.
-      <br><br>Part cooling is achieved via BerdAir system
-      .<br><br>Duct STL include on the Thingiverse page.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4238471">Thingiverse</item-button>
-      <item-button url="https://a360.co/2U1i6ob">CAD File</item-button>
-      <item-button url="bom/BOM_X_Hemera.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_X_Hemera.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="BMG/Titan Aqua" image="docs/assets/images/components/BMGAquaThumb.png">
-    <description slot="description">
-      This is the all metal BMG (Right Hand) paired with a Titan Aqua cooling plate,
-      <br>E3D Volcano
-      <br>and the E3D slim stepper.
-      <br><br>BLTouch and Optical endstop sensor mounts as well.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4411289">Thingiverse</item-button>
-      <item-button url="https://a360.co/3fY7MFT">CAD File</item-button>
-      <item-button url="bom/BOM_BMGAqua.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_BMGAqua.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
-  <item title="E3D Hemera Top Mounted and SuperVolcano" image="docs/assets/images/components/HemeraTopMountThumb.png">
-    <description slot="description">
-      This print head requires the use of E3D Super Volcano.
-      <br><br>Part cooling is achieved by BerdAir system.
-      <br><br>Bltouch and optical sensors are used for positioning.
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:4556554">Thingiverse</item-button>
-      <item-button url="https://a360.co/39ryl4z">CAD File</item-button>
-      <item-button url="bom/BOM_X_HemeraTopMount.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_X_HemeraTopMount.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
+<item title="E3D Hemera" image="docs/assets/images/components/HemeraThumb.png">
+  <description slot="description">
+    Including configuration for E3D V6,
+    <br>Volcano
+    <br>and Super Volcano heatblocks.
+    <br><br>Part cooling is achieved via BerdAir system
+    .<br><br>Duct STL include on the Thingiverse page.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4238471">Thingiverse</item-button>
+    <item-button url="https://a360.co/2U1i6ob">CAD File</item-button>
+    <item-button url="bom/BOM_X_Hemera.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_X_Hemera.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
+<item title="BMG/Titan Aqua" image="docs/assets/images/components/BMGAquaThumb.png">
+  <description slot="description">
+    This is the all metal BMG (Right Hand) paired with a Titan Aqua cooling plate,
+    <br>E3D Volcano
+    <br>and the E3D slim stepper.
+    <br><br>BLTouch and Optical endstop sensor mounts as well.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4411289">Thingiverse</item-button>
+    <item-button url="https://a360.co/3fY7MFT">CAD File</item-button>
+    <item-button url="bom/BOM_BMGAqua.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_BMGAqua.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>water cooled</item-tag>
+  </tags>
+</item>
+<item title="E3D Hemera Top Mounted and SuperVolcano" image="docs/assets/images/components/HemeraTopMountThumb.png">
+  <description slot="description">
+    This print head requires the use of E3D Super Volcano.
+    <br><br>Part cooling is achieved by BerdAir system.
+    <br><br>Bltouch and optical sensors are used for positioning.
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:4556554">Thingiverse</item-button>
+    <item-button url="https://a360.co/39ryl4z">CAD File</item-button>
+    <item-button url="bom/BOM_X_HemeraTopMount.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_X_HemeraTopMount.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+    <item-tag>Volcano</item-tag>
+  </tags>
+</item>
 </grid>
 
 ### HextrudORT
@@ -258,27 +302,31 @@ Supported print heads include (as of now):
 * Rapido (+UHF setup)
 
 <grid v-bind:config="{gridTemplateColumns: '1fr 1fr'}">
-  <item title="HextrudORT" image="docs/assets/images/components/HextrudORT_CoverThumb.jpg">
-    <description slot="description">
-      Collection of multiple print heads based on the HextrudORT (Extruder + Hotend) carriage
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://miragec79.github.io/HextrudORT">HextrudORT GitHub Page</item-button>
-    </buttons>
-  </item>
+<item title="HextrudORT" image="docs/assets/images/components/HextrudORT_CoverThumb.jpg">
+  <description slot="description">
+    Collection of multiple print heads based on the HextrudORT (Extruder + Hotend) carriage
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://miragec79.github.io/HextrudORT">HextrudORT GitHub Page</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
 </grid>
 
 ## 4. Electronics
 
 <grid v-bind:config="{gridTemplateColumns: '1fr 1fr'}">
-  <item title="Electronics" image="docs/assets/images/components/ElectronicsThumb.jpg">
-    <description slot="description">
-      Electronics List of material for Power Management and Control Board
-    </description>
-    <buttons slot="buttons">
-      <item-button url="https://www.thingiverse.com/thing:3953165">Electronics Island proposal</item-button>
-      <item-button url="bom/BOM_Electronics.htm">BOM - Web</item-button>
-      <item-button icon="fa fa-download" url="bom/BOM_Electronics.xlsx">BOM<br>Download</item-button>
-    </buttons>
-  </item>
+<item title="Electronics" image="docs/assets/images/components/ElectronicsThumb.jpg">
+  <description slot="description">
+    Electronics List of material for Power Management and Control Board
+  </description>
+  <buttons slot="buttons">
+    <item-button url="https://www.thingiverse.com/thing:3953165">Electronics Island proposal</item-button>
+    <item-button url="bom/BOM_Electronics.htm">BOM - Web</item-button>
+    <item-button icon="fa fa-download" url="bom/BOM_Electronics.xlsx">BOM<br>Download</item-button>
+  </buttons>
+  <tags slot="tags">
+  </tags>
+</item>
 </grid>

--- a/docs/pages/component-selection.md
+++ b/docs/pages/component-selection.md
@@ -16,6 +16,10 @@ This is the base of the HevORT
       <item-button url="bom/BOM_Frame_ElecExt.htm">BOM - Web</item-button>
       <item-button icon="fa fa-download" url="bom/BOM_Frame_ElecExt.xlsx">BOM<br>Download</item-button>
     </buttons>
+    <tags slot="tags">
+        <item-tag>Hallo</item-tag>
+        <item-tag>Test</item-tag>
+    </tags>
   </item>
   <item title="Enclosure" image="docs/assets/images/components/AcidBeeThumb.png">
     <description slot="description">

--- a/docs/pages/mods/mods.md
+++ b/docs/pages/mods/mods.md
@@ -37,6 +37,9 @@ If you need help, the best place to ask is the Discord server
     <buttons slot="buttons">
       <item-button url="https://www.printables.com/de/model/216056-hevort-acidbee-enclosure-extras">Printables</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Enclosure</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="Serbitar"/>
     </credits>
@@ -59,6 +62,10 @@ If you need help, the best place to ask is the Discord server
     <buttons slot="buttons">
       <item-button url="https://www.thingiverse.com/thing:5171980">Thingiverse</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>12mm belt</item-tag>
+      <item-tag>AWD</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="EvoMoto"/>
     </credits>
@@ -74,6 +81,10 @@ If you need help, the best place to ask is the Discord server
     <buttons slot="buttons">
       <item-button url="https://www.thingiverse.com/thing:4815859">Thingiverse</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>6mm belt</item-tag>
+      <item-tag>AWD</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="EvoMoto"/>
     </credits>
@@ -88,6 +99,10 @@ If you need help, the best place to ask is the Discord server
       <item-button url="https://www.thingiverse.com/thing:4946002">Thingiverse</item-button>
       <item-button url="https://a360.co/3lwUEMv">CAD File</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>12mm belt</item-tag>
+      <item-tag>AWD</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="Hans Hanson"/>
     </credits>
@@ -106,6 +121,9 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="files/Mods/rockzo_xyht_1515_extrusion_mod.step">CAD File</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>6mm belt</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="Rockzo"/>
     </credits>
@@ -125,6 +143,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="https://www.thingiverse.com/thing:4781610">Thingiverse</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>SFU1204</item-tag>
+      <item-tag>Wobble prevention</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="EvoMoto"/>
     </credits>
@@ -136,6 +158,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="https://www.thingiverse.com/thing:4785945">Thingiverse</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>SFU1604</item-tag>
+      <item-tag>Wobble prevention</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="EvoMoto"/>
     </credits>
@@ -158,6 +184,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="https://www.thingiverse.com/thing:4880007">Thingiverse</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Torque</item-tag>
+      <item-tag>increased travel</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="M3NT8L"/>
     </credits>
@@ -184,6 +214,11 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
                    url="https://hevort-mods.donnerplays.de/cad/BL_Touch_Rapido_Hotend_UHF_Bracket.step">CAD File
       </item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Bl-Touch</item-tag>
+      <item-tag>Rapido UHF</item-tag>
+      <item-tag>HextrudORT</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="MirageC">Initial work/version</credit>
       <credit name="DonnerPlays">Modification to use M3 nuts instead of threading into the plastic</credit>
@@ -197,6 +232,12 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="https://www.printables.com/de/model/151944-hevort-lgx-lite-hextrudort-carriage-mount-hd12mgn9">Printables</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>9mm belt</item-tag>
+      <item-tag>12mm belt</item-tag>
+      <item-tag>lgx lite</item-tag>
+      <item-tag>HextrudORT</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="Serbitar"/>
     </credits>
@@ -220,6 +261,12 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
         File
       </item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>CPAP</item-tag>
+      <item-tag>12mm belt</item-tag>
+      <item-tag>Rapido UHF</item-tag>
+      <item-tag>MGN12H</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="MirageC">Initial work of MGN9 version</credit>
       <credit name="DonnerPlays">Modification to fit HD12/MGN12</credit>
@@ -236,6 +283,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
         CAD File
       </item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Rapido UHF</item-tag>
+      <item-tag>Spacer</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="MirageC">Initial work of MGN9 version</credit>
       <credit name="DonnerPlays">Modification to fit HD12/MGN12</credit>
@@ -258,6 +309,12 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
                    url="https://hevort-mods.donnerplays.de/cad/MGN12_HD12_Rapido_Fan_Shroud_40mm.step">CAD File
       </item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Rapido</item-tag>
+      <item-tag>40mm fan</item-tag>
+      <item-tag>MGN12H</item-tag>
+      <item-tag>HD12</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="MirageC">Initial work on version for Rapido with 25mm fan</credit>
       <credit name="DonnerPlays">Modification to allow 40mm fan to be used</credit>
@@ -272,6 +329,11 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="https://hevort-mods.donnerplays.de/#/pages/mods/cpap_7040_solution.md">GitHub Page</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>CPAP</item-tag>
+      <item-tag>Mount</item-tag>
+      <item-tag>Spacer</item-tag>
+    </tags>
   </item>
 </grid>
 
@@ -286,6 +348,8 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
     <buttons slot="buttons">
       <item-button url="#/pages/mods/spy-eye.md">SpEye page</item-button>
     </buttons>
+    <tags slot="tags">
+    </tags>
     <credits slot="credits">
       <credit name="MirageC"/>
     </credits>
@@ -303,6 +367,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
         File
       </item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>40mm fan</item-tag>
+      <item-tag>ADXL345</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="DonnerPlays"/>
     </credits>
@@ -330,6 +398,10 @@ Smaller changes that may not fit into the bigger mods in the main [XY Gantry](#x
       <item-button url="https://www.thingiverse.com/thing:5197675">Thingiverse</item-button>
       <item-button url="https://a360.co/3lwUEMv">CAD File</item-button>
     </buttons>
+    <tags slot="tags">
+      <item-tag>Fume extractor</item-tag>
+      <item-tag>Fume filter</item-tag>
+    </tags>
     <credits slot="credits">
       <credit name="Hans Hanson"/>
     </credits>

--- a/index.html
+++ b/index.html
@@ -248,7 +248,6 @@
                   gridItemsData.forEach((gridItemData) => {
 
                     if (!gridItemData[propKey].includes(matchedAdvanced)) {
-                      console.log(gridItemData[propKey], matchedAdvanced);
                       const index = gridItemsData.indexOf(gridItemData);
                       if (index > -1) {
                         indexesToRemove.push(index);
@@ -264,8 +263,6 @@
                 }
               });
               unmatchedItems = gridItemsData.filter(x => !matchedItems.includes(x));
-              console.log(unmatchedItems);
-
             }
 
 
@@ -334,9 +331,6 @@
         `,
       },
       'tags': {
-        data: () => {
-
-        },
         template: `
           <div class="grid-item-tag-container">
             <slot></slot>
@@ -344,9 +338,6 @@
         `,
       },
       'item-tag': {
-        data: () => {
-
-        },
         template: `
           <span class="grid-item-tag">
             <slot></slot>

--- a/index.html
+++ b/index.html
@@ -126,15 +126,170 @@
             currentAnchoredElement.scrollIntoView();
           }, 2000);
         });
-      }
+      },
+      methods: {
+        getGridItemData: function (elementId) {
+          let element = document.querySelector(`#${elementId}`);
+
+          if (!element) {
+            return null;
+          }
+
+          let buttons = [];
+          element.querySelectorAll(".grid-item-container > .grid-item-button-container > a.hevort-btn").forEach((buttonElement) => {
+            buttons.push({title: buttonElement.querySelector(".hevort-btn-text").innerText, link: buttonElement.href})
+          });
+
+          let credits = [];
+          element.querySelectorAll(".grid-item-container > .grid-item-credits > .grid-item-credit-list > .grid-item-credit-list-item").forEach((creditElement) => {
+            credits.push({
+              name: creditElement.querySelector(".grid-item-credit-list-item-name").innerText,
+              description: creditElement.querySelector(".grid-item-credit-list-item-description").innerHTML
+            });
+          });
+
+          let titleWrapper = element.querySelector(".grid-item-title-wrapper > .grid-item-title-inner-wrapper");
+
+          let tags = [];
+
+          element.querySelectorAll(".grid-item-container > .grid-item-tag-container > .grid-item-tag").forEach((gridItemTagElement) => {
+            tags.push(gridItemTagElement.innerText);
+          })
+
+
+
+          return {
+            id: elementId,
+            title: titleWrapper.querySelector(".grid-item-title").innerHTML,
+            link: titleWrapper.querySelector(".grid-item-title").href,
+            state: titleWrapper.querySelector(".grid-item-state")?.innerHTML ?? "active",
+            image:  element.querySelector(".grid-item-container > img").src,
+            description:  element.querySelector(".grid-item-container > .grid-item-description-container > .grid-item-description").innerHTML,
+            tags: tags,
+            buttons: buttons,
+            credits: credits
+          }
+        },
+      },
     },
     vueComponents: {
       'grid': {
         template: `
           <div class="grid" :style="[config.gridTemplateColumns ? {'gridTemplateColumns': config.gridTemplateColumns} : {'gridTemplateColumns': '1fr 1fr 1fr'}]">
-          <slot></slot>
+          <span class="grid-search">
+            <label class="grid-search-label">Search component</label>
+            <input class="grid-search-input" @input="(e) => filterGridItems(e.target.value)" />
+          </span>
+          <span ref="emptySearchItem" class="grid-data-container-empty-search" style="display: none"><i class="hevort-color fa-regular fa-face-frown hevort"></i> looks like there is nothing here <i class="hevort-color fa-regular fa-face-frown hevort"></span>
+          <div ref="gridDataContainer" class="grid-data-container">
+            <slot></slot>
+          </div>
           </div>
         `,
+        data: () => {
+          return {
+            availableFilters: [
+                    "id",
+                    "description",
+                    "title",
+                    "tags",
+                    "state"
+            ],
+            gridItems: []
+          }
+        },
+        mounted: function () {
+          this.gridItems = this.$refs?.gridDataContainer?.children;
+          this.emptySearchItem = this.$refs?.emptySearchItem;
+        },
+        methods: {
+          filterGridItems: function (text) {
+            let matchedData = {
+              id: [],
+              description: [],
+              title: [],
+              tags: [],
+              state: [],
+            };
+
+            let anyAdvancedFilter = false;
+            this.availableFilters.forEach((filterName) => {
+              let regEx = new RegExp(`${filterName}="(.*?)"`, "g");
+              let match;
+              while (match = regEx.exec(text)) {
+                matchedData[filterName].push(match[1]);
+                anyAdvancedFilter = true;
+              }
+            })
+
+
+            let matchedItems = [];
+            let unmatchedItems = [];
+            let gridItemsData = [];
+            Array.from(this.gridItems).forEach((gridItem) => {
+              gridItemsData.push(this.$root.getGridItemData(gridItem.id));
+            })
+
+
+            if (!anyAdvancedFilter) {
+              Object.keys(matchedData).forEach((propKey) => {
+                gridItemsData.forEach((gridItemData) => {
+                  if (gridItemData[propKey].includes(text) && !matchedItems.includes(gridItemData)) {
+                    matchedItems.push(gridItemData);
+                  }
+                })
+              });
+
+              unmatchedItems = gridItemsData.filter(x => !matchedItems.includes(x));
+            } else {
+              let indexesToRemove = [];
+              Object.keys(matchedData).forEach((propKey) => {
+                matchedData[propKey].forEach((matchedAdvanced) => {
+                  gridItemsData.forEach((gridItemData) => {
+
+                    if (!gridItemData[propKey].includes(matchedAdvanced)) {
+                      console.log(gridItemData[propKey], matchedAdvanced);
+                      const index = gridItemsData.indexOf(gridItemData);
+                      if (index > -1) {
+                        indexesToRemove.push(index);
+                      }
+                    }
+                  })
+                });
+              });
+
+              gridItemsData.forEach((gridItemData, index) => {
+                if (!indexesToRemove.includes(index)) {
+                  matchedItems.push(gridItemData);
+                }
+              });
+              unmatchedItems = gridItemsData.filter(x => !matchedItems.includes(x));
+              console.log(unmatchedItems);
+
+            }
+
+
+            if (matchedItems.length === 0) {
+              this.emptySearchItem.style.removeProperty("display");
+            }
+
+            matchedItems.forEach((matchedItem) => {
+              let element = document.querySelector(`#${matchedItem.id}`);
+              if (element) {
+                element.style.removeProperty("display");
+                if (this.emptySearchItem.style.display !== "none") {
+                  this.emptySearchItem.style.display = "none";
+                }
+              }
+            });
+            unmatchedItems.forEach((matchedItem) => {
+              let element = document.querySelector(`#${matchedItem.id}`);
+              if (element) {
+                element.style.display = "none";
+              }
+            });
+          },
+        },
         props: {
           config: {
             type: Object,
@@ -176,6 +331,26 @@
               </span>
           </div>
           </li>
+        `,
+      },
+      'tags': {
+        data: () => {
+
+        },
+        template: `
+          <div class="grid-item-tag-container">
+            <slot></slot>
+          </div>
+        `,
+      },
+      'item-tag': {
+        data: () => {
+
+        },
+        template: `
+          <span class="grid-item-tag">
+            <slot></slot>
+          </span>
         `,
       },
       'buttons': {
@@ -341,6 +516,7 @@
                   <span class="grid-item-state" v-if="status" v-text="status"></span>
                 </span>
                 <div class="grid-item-container">
+                  <slot name="tags"></slot>
                   <img v-if="image" alt="IMAGE" ref="image" :style="[descriptionElmExists ? {} :{'border': '1px solid var(--primary-color) !important', 'borderRadius': '1rem'}]" class="grid-item-image" :src=image />
                   <slot name="description"><span style="margin-bottom: 1rem"></span></slot>
                   <slot name="credits"><div style="margin-top: auto"></div></slot>

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
           element.querySelectorAll(".grid-item-container > .grid-item-credits > .grid-item-credit-list > .grid-item-credit-list-item").forEach((creditElement) => {
             credits.push({
               name: creditElement.querySelector(".grid-item-credit-list-item-name").innerText,
-              description: creditElement.querySelector(".grid-item-credit-list-item-description").innerHTML
+              description: creditElement.querySelector(".grid-item-credit-list-item-description")?.innerHTML ?? ""
             });
           });
 
@@ -165,7 +165,7 @@
             state: titleWrapper.querySelector(".grid-item-state")?.innerHTML ?? "active",
             image:  element.querySelector(".grid-item-container > img").src,
             description:  element.querySelector(".grid-item-container > .grid-item-description-container > .grid-item-description").innerHTML,
-            tags: tags,
+            tag: tags,
             buttons: buttons,
             credits: credits
           }
@@ -178,7 +178,8 @@
           <div class="grid" :style="[config.gridTemplateColumns ? {'gridTemplateColumns': config.gridTemplateColumns} : {'gridTemplateColumns': '1fr 1fr 1fr'}]">
           <span class="grid-search">
             <label class="grid-search-label">Search component</label>
-            <input class="grid-search-input" @input="(e) => filterGridItems(e.target.value)" />
+            <input class="grid-search-input" placeholder="Start typing to search..." @input="(e) => filterGridItems(e.target.value)" />
+            <span class="grid-search-info" v-html="getAvailableFiltersInfoText()" />
           </span>
           <span ref="emptySearchItem" class="grid-data-container-empty-search" style="display: none"><i class="hevort-color fa-regular fa-face-frown hevort"></i> looks like there is nothing here <i class="hevort-color fa-regular fa-face-frown hevort"></span>
           <div ref="gridDataContainer" class="grid-data-container">
@@ -192,7 +193,7 @@
                     "id",
                     "description",
                     "title",
-                    "tags",
+                    "tag",
                     "state"
             ],
             gridItems: []
@@ -203,50 +204,124 @@
           this.emptySearchItem = this.$refs?.emptySearchItem;
         },
         methods: {
-          filterGridItems: function (text) {
-            let matchedData = {
+          getAvailableFiltersInfoText: function () {
+            let text = "Available filters: ";
+            this.availableFilters.forEach((availableFilter, index) => {
+
+              let filterHtml = `<span class="grid-search-info-filter">${availableFilter}</span>`
+              text += `${filterHtml}=""`;
+              if (index !== this.availableFilters.length - 1) {
+                text += ", ";
+              }
+            });
+
+            return text;
+          },
+          isAnyAdvancedFilter: function (text) {
+            for(let i = 0; i < this.availableFilters.length; i++) {
+              let filterName = this.availableFilters[i];
+              let regEx = new RegExp(`${filterName}="(.*?)"`, "g");
+              let match;
+              while (match = regEx.exec(text)) {
+                return true;
+              }
+            }
+            return false;
+          },
+          getAdvancedFilterData: function(text) {
+            let advancedFilterData = {
               id: [],
               description: [],
               title: [],
-              tags: [],
+              tag: [],
               state: [],
             };
 
-            let anyAdvancedFilter = false;
             this.availableFilters.forEach((filterName) => {
               let regEx = new RegExp(`${filterName}="(.*?)"`, "g");
               let match;
               while (match = regEx.exec(text)) {
-                matchedData[filterName].push(match[1]);
-                anyAdvancedFilter = true;
+                advancedFilterData[filterName].push(match[1]);
               }
-            })
-
-
-            let matchedItems = [];
-            let unmatchedItems = [];
+            });
+            return advancedFilterData;
+          },
+          filterGridItems: function (text) {
+            let advancedFilterData = this.getAdvancedFilterData(text);
             let gridItemsData = [];
             Array.from(this.gridItems).forEach((gridItem) => {
               gridItemsData.push(this.$root.getGridItemData(gridItem.id));
             })
 
+            if (!this.isAnyAdvancedFilter(text)) {
+              this.handleFilterItemsNormal(advancedFilterData, text);
+            } else {
+              this.handleFilterItemsAdvanced(advancedFilterData, text);
+            }
+          },
+          getGridItemData: function ()
+          {
+            let gridItemsData = [];
+            Array.from(this.gridItems).forEach((gridItem) => {
+              gridItemsData.push(this.$root.getGridItemData(gridItem.id));
+            })
+            return gridItemsData;
+          },
+          handleFilterItemsNormal: function (advancedFilterData, text) {
+            let itemsToShow = [];
+            let gridItemsData = this.getGridItemData();
 
-            if (!anyAdvancedFilter) {
-              Object.keys(matchedData).forEach((propKey) => {
-                gridItemsData.forEach((gridItemData) => {
-                  if (gridItemData[propKey].includes(text) && !matchedItems.includes(gridItemData)) {
-                    matchedItems.push(gridItemData);
+            Object.keys(advancedFilterData).forEach((propKey) => {
+              gridItemsData.forEach((gridItemData) => {
+                let found = false;
+                if (propKey === "tag") {
+                  gridItemData[propKey].forEach((tag) => {
+                    if (tag.includes(text) && !itemsToShow.includes(gridItemData)) {
+                      found = true;
+                    }
+                  })
+                } else if (gridItemData[propKey].includes(text) && !itemsToShow.includes(gridItemData)) {
+                  found = true;
+                }
+
+                if (found) {
+                  itemsToShow.push(gridItemData);
+                }
+              });
+            });
+
+            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)));
+          },
+          handleFilterItemsAdvanced: function (advancedFilterData, text) {
+            let indexesToRemove = [];
+            let itemsToShow = [];
+            let gridItemsData = this.getGridItemData();
+
+            let tagFilterData = advancedFilterData.tag;
+            gridItemsData.forEach((gridItemData) => {
+              let matchingCount = 0;
+              tagFilterData.forEach((tagFilter) => {
+                gridItemData.tag.forEach((tag) => {
+                  if (tag.includes(tagFilter)) {
+                    matchingCount++;
                   }
                 })
-              });
 
-              unmatchedItems = gridItemsData.filter(x => !matchedItems.includes(x));
-            } else {
-              let indexesToRemove = [];
-              Object.keys(matchedData).forEach((propKey) => {
-                matchedData[propKey].forEach((matchedAdvanced) => {
+              })
+
+              if (matchingCount !== tagFilterData.length) {
+                const index = gridItemsData.indexOf(gridItemData);
+                if (index > -1) {
+                  indexesToRemove.push(index);
+                }
+              }
+            });
+
+
+            Object.keys(advancedFilterData).forEach((propKey) => {
+              if (propKey !== "tag") {
+                advancedFilterData[propKey].forEach((matchedAdvanced) => {
                   gridItemsData.forEach((gridItemData) => {
-
                     if (!gridItemData[propKey].includes(matchedAdvanced)) {
                       const index = gridItemsData.indexOf(gridItemData);
                       if (index > -1) {
@@ -255,22 +330,23 @@
                     }
                   })
                 });
-              });
+              }
+            });
 
-              gridItemsData.forEach((gridItemData, index) => {
-                if (!indexesToRemove.includes(index)) {
-                  matchedItems.push(gridItemData);
-                }
-              });
-              unmatchedItems = gridItemsData.filter(x => !matchedItems.includes(x));
-            }
+            gridItemsData.forEach((gridItemData, index) => {
+              if (!indexesToRemove.includes(index)) {
+                itemsToShow.push(gridItemData);
+              }
+            });
 
-
-            if (matchedItems.length === 0) {
+            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)))
+          },
+          handleItemVisibility: function (itemsToShow, itemsToHide) {
+            if (itemsToShow.length === 0) {
               this.emptySearchItem.style.removeProperty("display");
             }
 
-            matchedItems.forEach((matchedItem) => {
+            itemsToShow.forEach((matchedItem) => {
               let element = document.querySelector(`#${matchedItem.id}`);
               if (element) {
                 element.style.removeProperty("display");
@@ -279,7 +355,7 @@
                 }
               }
             });
-            unmatchedItems.forEach((matchedItem) => {
+            itemsToHide.forEach((matchedItem) => {
               let element = document.querySelector(`#${matchedItem.id}`);
               if (element) {
                 element.style.display = "none";
@@ -332,14 +408,33 @@
       },
       'tags': {
         template: `
-          <div class="grid-item-tag-container">
+          <div class="grid-item-tag-container" slot="tags">
             <slot></slot>
           </div>
         `,
       },
       'item-tag': {
+        methods: {
+          onClick: function (text) {
+            let searchInput = this.$parent.$parent.$parent.$el.querySelector(".grid-search > input.grid-search-input");
+            if (!searchInput) {
+              return;
+            }
+
+            let value = searchInput.value;
+            if (!value.endsWith(" ")) {
+              searchInput.value += " ";
+            }
+
+            searchInput.value += `tag="${text}"`;
+
+            let event = new Event('input');
+
+            searchInput.dispatchEvent(event);
+          }
+        },
         template: `
-          <span class="grid-item-tag">
+          <span @click="(event) => onClick(event.target.innerText)" class="grid-item-tag">
             <slot></slot>
           </span>
         `,

--- a/index.html
+++ b/index.html
@@ -152,11 +152,9 @@
 
           let tags = [];
 
-          element.querySelectorAll(".grid-item-container > .grid-item-tag-container > .grid-item-tag").forEach((gridItemTagElement) => {
+          element.querySelectorAll(".grid-item-container > .grid-item-tag-container > .grid-item-tag-inner-container > .grid-item-tag").forEach((gridItemTagElement) => {
             tags.push(gridItemTagElement.innerText);
           })
-
-
 
           return {
             id: elementId,
@@ -317,7 +315,6 @@
               }
             });
 
-
             Object.keys(advancedFilterData).forEach((propKey) => {
               if (propKey !== "tag") {
                 advancedFilterData[propKey].forEach((matchedAdvanced) => {
@@ -407,34 +404,68 @@
         `,
       },
       'tags': {
+        data: () => {
+          return {
+            childs: []
+          }
+        },
+        mounted: function () {
+          this.childs = this.$refs?.tags?.children;
+        },
+        computed: {
+          childCount: function () {
+            return this.childs.length;
+          }
+        },
         template: `
-          <div class="grid-item-tag-container" slot="tags">
-            <slot></slot>
+          <div class="grid-item-tag-container" :style="[childCount === 0 ? {'display': 'none'} : {}]" slot="tags" >
+            <span class="grid-item-tag-title">Tags:</span>
+            <div class="grid-item-tag-inner-container" ref="tags">
+                <slot></slot>
+            </div>
           </div>
         `,
       },
       'item-tag': {
         methods: {
-          onClick: function (text) {
+          onClick: function (event) {
+            let tagElement = event.target;
+            let text = tagElement.innerText;
+
             let searchInput = this.$parent.$parent.$parent.$el.querySelector(".grid-search > input.grid-search-input");
             if (!searchInput) {
               return;
             }
 
-            let value = searchInput.value;
-            if (!value.endsWith(" ")) {
-              searchInput.value += " ";
+            let tagText = `tag="${text}"`;
+
+            if (tagElement.classList.contains("grid-item-tag-remove")) {
+              tagElement.classList.remove("grid-item-tag-remove");
+              searchInput.value = searchInput.value
+                      .replaceAll(tagText, "")
+                      .replaceAll("  ", " ");
+              if (searchInput.value === " ") {
+                searchInput.value = searchInput.value.replaceAll(" ", "");
+              }
+            } else {
+              if (searchInput.value.includes(tagText)) {
+                tagElement.classList.add("grid-item-tag-remove");
+              } else {
+                if (!searchInput.value.endsWith(" ")) {
+                  searchInput.value += " ";
+                }
+                searchInput.value += tagText;
+              }
+
+
+              tagElement.classList.add("grid-item-tag-remove");
             }
 
-            searchInput.value += `tag="${text}"`;
-
-            let event = new Event('input');
-
-            searchInput.dispatchEvent(event);
+            searchInput.dispatchEvent(new Event('input'));
           }
         },
         template: `
-          <span @click="(event) => onClick(event.target.innerText)" class="grid-item-tag">
+          <span @click="onClick" class="grid-item-tag">
             <slot></slot>
           </span>
         `,


### PR DESCRIPTION
- Allows searching in every text of a grid-item (title, description, tags)
- Allows searching using filters like ``tag="AWD" tag="Nema23"``
  - Result: only grid-items with the tags "AWD" & "Nema23" are visible.
  - Tags on grid-items can be clicked and will be added to the search
    - Clicking a tag with the same name again will remove it from the search
  - Once an advanced filter is detected in the search bar, no other text is processed, except filters
  
# Example

### Before
![before](https://user-images.githubusercontent.com/19359112/182020401-9740631d-90eb-4edc-85f8-f1e8f9219f66.png)

### After
![after](https://user-images.githubusercontent.com/19359112/182020407-8cda5401-8e79-4b2c-830e-6040d87142e6.png)

 