### PR TITLE
Implement pagination feature

### DIFF
--- a/docs/assets/css/grid.css
+++ b/docs/assets/css/grid.css
@@ -45,6 +45,10 @@
     color: var(--primary-color);
 }
 
+.grid-search-item-hidden {
+    display: none !important;
+}
+
 .grid-data-container {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
@@ -346,6 +350,50 @@
     padding: 0.5rem;
     font-weight: bold;
     margin-left: 1rem;
+}
+
+.grid-pagination {
+    display: flex;
+    gap: 0.5rem;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    padding-top: 0.5rem;
+}
+
+.grid-item.grid-pagination-item-hidden {
+    display: none;
+}
+
+.grid-pagination-page-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border: 2px solid var(--primary-color);
+    background: var(--secondary-background-color);
+    color: white;
+    font-weight: bold;
+    border-radius: 1rem;
+    padding: 0.25rem;
+}
+
+.grid-pagination-page-button:hover {
+    cursor: pointer;
+    background-color: var(--secondary-color);
+    color: white;
+}
+
+.grid-pagination-page-button:active {
+    transform: translateY(4px);
+
+}
+
+.grid-pagination-page-button-selected {
+    transform: translateY(4px);
+    color: black;
+    background-color: var(--primary-color);
+
 }
 
 .grid-item-tag-container {

--- a/docs/pages/component-selection.md
+++ b/docs/pages/component-selection.md
@@ -5,7 +5,7 @@ The HevORT project has been designed to be modular. This means you can select fr
 ## 1. Frame/Enclosure
 This is the base of the HevORT
 
-<grid v-bind:config="{gridTemplateColumns: '1fr 1fr'}">
+<grid columns="1fr 1fr">
 <item title="Frame" image="docs/assets/images/components/FrameThumb.png">
   <description slot="description">
     The bare base frame with a side electronics bay
@@ -301,7 +301,7 @@ Supported print heads include (as of now):
 * E3D V6 (+Volcano)
 * Rapido (+UHF setup)
 
-<grid v-bind:config="{gridTemplateColumns: '1fr 1fr'}">
+<grid columns="1fr 1fr">
 <item title="HextrudORT" image="docs/assets/images/components/HextrudORT_CoverThumb.jpg">
   <description slot="description">
     Collection of multiple print heads based on the HextrudORT (Extruder + Hotend) carriage

--- a/docs/pages/documentation-docs.md
+++ b/docs/pages/documentation-docs.md
@@ -56,7 +56,7 @@ To have a unified way of showing a large amount of related parts we use the grid
 
 ### Usage
 ````vue
-<grid v-bind:config="{gridTemplateColumns: '1fr 1fr 1fr'}">
+<grid columns="1fr 1fr 1fr">
   <item title="Item title" image="https://via.placeholder.com/400.png/FF0000/000000?text=Placeholder+Image" status="I'm active">
     <description slot="description">
       Full html support description text
@@ -80,7 +80,7 @@ To have a unified way of showing a large amount of related parts we use the grid
 ````
 
 ### Result
-<grid v-bind:config="{gridTemplateColumns: '1fr 1fr 1fr'}">
+<grid columns="1fr 1fr 1fr">
   <item title="Item title" image="https://via.placeholder.com/400.png/FF0000/000000?text=Placeholder+Image" status="I'm active">
     <description slot="description">
       Full html support description text
@@ -113,13 +113,14 @@ If a component below does not mention any **Attributes** or **Content** point, t
 - grid
   - **REQUIRED**
   - attributes
-    - v-bind:config="{}"
+    - columns
       - **OPTIONAL**
-      - configuration for this grid item goes in between the ``{}``
-      - default: {gridTemplateColumns: '1fr 1fr 1fr'}
-      - options:
-        - gridTemplateColumns
-          - example: {gridTemplateColumns: '1fr 1fr'} = results in a 2 column grid
+      - default: "1fr 1fr 1fr"
+      - example: "1fr 1fr" = results in a 2 column grid
+    - items_per_page
+      - **OPTIONAL**
+      - default: 6
+      - example: 3 = results in 3 items visible per page. With 12 total items that will result in 4 pages ( 12 / 3 = 4)
 - item
   - attributes
     - title

--- a/index.html
+++ b/index.html
@@ -184,16 +184,17 @@
     vueComponents: {
       'grid': {
         template: `
-          <div class="grid" :style="[config.gridTemplateColumns ? {'gridTemplateColumns': config.gridTemplateColumns} : {'gridTemplateColumns': '1fr 1fr 1fr'}]">
+          <div class="grid">
           <span class="grid-search">
             <label class="grid-search-label">Search component</label>
             <input class="grid-search-input" placeholder="Start typing to search..." @input="(e) => filterGridItems(e.target.value)" />
             <span class="grid-search-info" v-html="getAvailableFiltersInfoText()" />
           </span>
           <span ref="emptySearchItem" class="grid-data-container-empty-search" style="display: none"><i class="hevort-color fa-regular fa-face-frown hevort"></i> looks like there is nothing here <i class="hevort-color fa-regular fa-face-frown hevort"/></span>
-          <div ref="gridDataContainer" class="grid-data-container">
+          <div class="grid-data-container" :style="[columns ? {'gridTemplateColumns': columns} : {'gridTemplateColumns': '1fr 1fr 1fr'}]">
             <slot></slot>
           </div>
+          <span class="grid-pagination" ref="gridPagination" v-html="getPaginationControls"></span>
           </div>
         `,
         data: () => {
@@ -205,14 +206,88 @@
                     "tag",
                     "state"
             ],
-            gridItems: []
+            gridItems: [],
+            currentPage: 0,
+            emptySearchItem: null,
+            gridPaginationElm: null,
+            paginatedGridItems: [],
           }
         },
         mounted: function () {
-          this.gridItems = this.$refs?.gridDataContainer?.children;
+          this.items_per_page = parseInt(this.items_per_page, 10);
+          this.gridItems = this.$children;
           this.emptySearchItem = this.$refs?.emptySearchItem;
+          this.gridPaginationElm = this.$refs?.gridPagination;
+          let pageCounter = 0;
+          let paginationCounter = 0;
+
+          this.gridItems.forEach((item) => {
+            if (!this.paginatedGridItems[pageCounter]) {
+              this.paginatedGridItems[pageCounter] = [];
+            }
+            if (pageCounter !== 0) {
+              item.$el.classList.add("grid-pagination-item-hidden");
+            }
+            this.paginatedGridItems[pageCounter].push(item);
+
+            paginationCounter++;
+            if (paginationCounter >= this.items_per_page) {
+              paginationCounter = 0;
+              pageCounter++;
+            }
+          });
+        },
+        computed: {
+          getPaginationControls: function (el) {
+            if (this.gridItems.length === 0) {
+              return "";
+            }
+
+            let paginationGridItemsArray = Object.keys(this.paginatedGridItems);
+
+            if (paginationGridItemsArray.length === 1) {
+              return;
+            }
+
+            paginationGridItemsArray.forEach((pageIndex) => {
+              pageIndex = parseInt(pageIndex, 10);
+              let buttonElement = document.createElement("button");
+              buttonElement.className = "grid-pagination-page-button";
+              buttonElement.innerText = (pageIndex + 1).toString(10);
+              if (pageIndex === 0) {
+                buttonElement.classList.add("grid-pagination-page-button-selected");
+              }
+              buttonElement.addEventListener("click", () => this.switchPage(pageIndex, buttonElement))
+              this.gridPaginationElm.append(buttonElement);
+            });
+          },
         },
         methods: {
+          switchPage: function (newPageIndex, clickedButtonElm) {
+            let previouslySelectedButton = this.gridPaginationElm.querySelector("button.grid-pagination-page-button-selected");
+
+            if (previouslySelectedButton === clickedButtonElm) {
+              return;
+            }
+
+            clickedButtonElm.classList.add("grid-pagination-page-button-selected");
+            if (!previouslySelectedButton) {
+              return;
+            }
+            previouslySelectedButton.classList.remove("grid-pagination-page-button-selected");
+
+            Object.keys(this.paginatedGridItems).forEach((pageIndex) => {
+              pageIndex = parseInt(pageIndex, 10);
+              let paginatedGridItems = this.paginatedGridItems[pageIndex];
+              paginatedGridItems.forEach((item) => {
+                if (newPageIndex === pageIndex) {
+                  item.$el.classList.remove("grid-pagination-item-hidden");
+                } else {
+                  item.$el.classList.add("grid-pagination-item-hidden");
+                }
+              });
+            })
+          },
           getAvailableFiltersInfoText: function () {
             let text = "Available filters: ";
             this.availableFilters.forEach((availableFilter, index) => {
@@ -259,7 +334,7 @@
             let advancedFilterData = this.getAdvancedFilterData(text);
             let gridItemsData = [];
             Array.from(this.gridItems).forEach((gridItem) => {
-              gridItemsData.push(this.$root.getGridItemData(gridItem.id));
+              gridItemsData.push(this.$root.getGridItemData(gridItem.$el.id));
             })
 
             if (!this.isAnyAdvancedFilter(text)) {
@@ -272,7 +347,7 @@
           {
             let gridItemsData = [];
             Array.from(this.gridItems).forEach((gridItem) => {
-              gridItemsData.push(this.$root.getGridItemData(gridItem.id));
+              gridItemsData.push(this.$root.getGridItemData(gridItem.$el.id));
             })
             return gridItemsData;
           },
@@ -299,7 +374,7 @@
               });
             });
 
-            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)));
+            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)), text === "");
           },
           handleFilterItemsAdvanced: function (advancedFilterData, text) {
             let indexesToRemove = [];
@@ -347,17 +422,24 @@
               }
             });
 
-            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)))
+            this.handleItemVisibility(itemsToShow, gridItemsData.filter(x => !itemsToShow.includes(x)), text === "")
           },
-          handleItemVisibility: function (itemsToShow, itemsToHide) {
+          handleItemVisibility: function (itemsToShow, itemsToHide, searchInputEmpty) {
             if (itemsToShow.length === 0) {
               this.emptySearchItem.style.removeProperty("display");
             }
-
+            
             itemsToShow.forEach((matchedItem) => {
               let element = document.querySelector(`#${matchedItem.id}`);
               if (element) {
-                element.style.removeProperty("display");
+                if (element.classList.contains("grid-pagination-item-hidden")) {
+                  element.style.setProperty("display", "flex", "important");
+
+                  if (searchInputEmpty) {
+                    element.style.removeProperty("display");
+                  }
+                }
+                element.classList.remove("grid-search-item-hidden");
                 if (this.emptySearchItem.style.display !== "none") {
                   this.emptySearchItem.style.display = "none";
                 }
@@ -366,17 +448,22 @@
             itemsToHide.forEach((matchedItem) => {
               let element = document.querySelector(`#${matchedItem.id}`);
               if (element) {
-                element.style.display = "none";
+                element.classList.add("grid-search-item-hidden");
+                if (element.classList.contains("grid-pagination-item-hidden")) {
+                  element.style.removeProperty("display");
+                }
               }
             });
           },
         },
         props: {
-          config: {
-            type: Object,
-            default: () => {
-              return {gridTemplateColumns: '1fr 1fr 1fr'}
-            }
+          items_per_page: {
+            type: Number,
+            default: () => 6
+          },
+          columns: {
+            type: String,
+            default: () => "1fr 1fr 1fr"
           }
         }
       },
@@ -686,6 +773,9 @@
             });
             this.$el.classList.add("link-selected-anchor");
             this.$el.scrollIntoView({behavior: "smooth"});
+          },
+          setVisible: function (visible = true) {
+            this.$el.style.display = visible ? "flex" : "none";
           }
         },
         template: `


### PR DESCRIPTION
Adds pagination (splitting items into multiple pages).

Current default is 6 items. If more than 6 items are added to a grid. pages will be displayed (max(7 items / 6) = 2 pages)

if no page is needed. The controls for the pages are not visible.

When searching using the search-input. Searching works everywhere. Even items on a different page will be found & displayed.
Once the search-input is cleared. The "hidden by page" items are hidden again.
![2022-10-04_18-08](https://user-images.githubusercontent.com/19359112/193870657-fc912754-9c75-47d2-a771-98e326433f67.png)
