### PR TITLE
Add Calistar to useful stuff section

### DIFF
--- a/docs/pages/useful-stuff/links.md
+++ b/docs/pages/useful-stuff/links.md
@@ -9,8 +9,9 @@
 
 ## External
 
-| Name/Link                                                                 | Description                                                                                                                                                                     |
-|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [>>Flow Rate Calculator<<](https://polygno.com/flow_rate_calculator)      | This is a useful tool to check how much<br>flow rate your current settings might result in.                                                                                     | 
-| [>>Retraction Calibration Generator<<](http://retractioncalibration.com/) | This website generates an advanced retraction calibration test<br>It allows to test multiple parameters in one test.<br>Like temperature, retraction distance, retraction speed |
-| [>>EMF Calculator<<](https://www.reprapfirmware.org/emf.html)             | This calculator will tell you how fast you can go before EMF (noise) might become an issue or to much                                                                           |
+| Name/Link                                                                           | Description                                                                                                                                                                     |
+|-------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [>>Flow Rate Calculator<<](https://polygno.com/flow_rate_calculator)                | This is a useful tool to check how much<br>flow rate your current settings might result in.                                                                                     | 
+| [>>Retraction Calibration Generator<<](http://retractioncalibration.com/)           | This website generates an advanced retraction calibration test<br>It allows to test multiple parameters in one test.<br>Like temperature, retraction distance, retraction speed |
+| [>>EMF Calculator<<](https://www.reprapfirmware.org/emf.html)                       | This calculator will tell you how fast you can go before EMF (noise) might become an issue or to much                                                                           |
+| [>>Dimensional Accuracy Calibration<<](https://github.com/dirtdigger/fleur_de_cali) | Calistar is a calibration print and spreadsheet combo to tune dimensional accuracy and skew                                                                                     |


### PR DESCRIPTION
From Calistar's description:


![image](https://github.com/MirageC79/HevORT/assets/1042652/d04a901d-ed26-4e17-801e-1ba05d374dea)

> This is a free, open source, parametric tool used for adjusting the dimensional correctness and skew of your printer. This model performs a similar function to other prints such as Califlower, but has no relation to nor has been derived from any part of those. Turns out that the math behind printer skew calibration has been around since Euclid, and its application to 3D printers is well-documented on other open source project's websites like Klipper. Getting the best performance out of your printer shouldn't be behind a paywall.
>
> Features:

> - Parametric design. Try this with other calibration prints: scale up the model by 20%. You'll find your print time and material used increase by up to 50% since the thickness of the print also increases. Using this design, load up a different stl to keep the thickness the same. Your print time and material used only increase by about 20%
> - Bigger is better. No calipers are perfect. Printing larger calibration prints decreases the relative error of your measurements. Included is up to 180mm full size, but make sure you've got calipers that can go that large before printing.
> - Multiple measurement points. Measure as many locations as you want up to three times. If you get bored of measuring, stop. If you only want to measure two outermost points since they give the highest signal-to-noise ratio, do that. The spreadsheet is smart enough to figure it out. Just make sure for every outer measurement you have a corresponding inner measurement to offset incorrect flow calibration.
> - Know when to stop. Along with offsets, error estimation based on the variance of your measurements and the error in your calipers are provided. If you're probably fixing noise, the spreadsheet will tell you.